### PR TITLE
➕ [feat] : 도커 가상화 환경 CI 구축 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      #자바버전 17 세팅
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+
       #githubsecrets yml 환경변수 주입.
       - name: Set Yaml
         uses: microsoft/variable-substitution@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,52 @@
+name: CI
+
+# main,cicd 브랜치에 push, PR 이벤트 발생시 동작.
+on:
+  push:
+    branches:
+      - 'main'
+      - 'cicd'
+  pull_request:
+    branches:
+      - 'main'
+      - 'cicd'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      #githubsecrets yml 환경변수 주입.
+      - name: Set Yaml
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/main/resources/application.yml
+        env:
+          spring.datasource.url: ${{ secrets.DB_URL }}
+          spring.datasource.username: ${{ secrets.DB_USERNAME }}
+          spring.datasource.password: ${{ secrets.DB_PASSWORD }}
+
+      #gradlew 실행을 위한 권한 추가
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Spring Boot 어플리케이션 Build (1)
+      - name: Spring Boot Build
+        run: ./gradlew clean build -x test
+
+      # Docker 이미지 Build (2) : 최동훈 도커허브이용
+      - name: docker image build
+        run: docker build -t ulsandonghun/zigzzang .
+
+      # DockerHub Login (3)
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Docker Hub push (4)
+      - name: docker Hub push
+        run: docker push ulsandonghun/zigzzang

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# 최신 17-jdk 이미지로 부터 시작
+FROM openjdk:17-jdk
+
+# 인자 정리
+ARG JAR_FILE=build/libs/*.jar
+
+# 앞에는 HOST OS의 현재 폴더를 의미
+# 뒤에는 컨테이너의 현재 폴더(WORKDIR)를 의미
+COPY ${JAR_FILE} app.jar
+
+# docker container에서 실행되는 명령어
+ENTRYPOINT ["java","-jar","-DDB_DRIVER=com.mysql.cj.jdbc.Driver","-DDB_PASSWORD=vdongv1620","-DDB_URL=jdbc:mysql://zigzzang-db.c74u6wukkm5o.ap-northeast-2.rds.amazonaws.com:3306/zigzzang","-DDB_USER=admin","/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # docker container에서 실행되는 명령어
-ENTRYPOINT ["java","-jar","-DDB_DRIVER=com.mysql.cj.jdbc.Driver","-DDB_PASSWORD=vdongv1620","-DDB_URL=jdbc:mysql://zigzzang-db.c74u6wukkm5o.ap-northeast-2.rds.amazonaws.com:3306/zigzzang","-DDB_USER=admin","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # docker container에서 실행되는 명령어
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","-DDB_DRIVER=com.mysql.cj.jdbc.Driver","-DDB_PASSWORD=vdongv1620","-DDB_URL=jdbc:mysql://zigzzang-db.c74u6wukkm5o.ap-northeast-2.rds.amazonaws.com:3306/zigzzang","-DDB_USER=admin","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -35,3 +35,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+jar {
+	enabled = false
+}


### PR DESCRIPTION
### 요약 

`DOCKER`를 이용하여 가상화 컨테이너 기반 CI 환경을 구축하였습니다. 
`Jar 빌드` -> `Docker Image 생성` -> `Docker Hub` 과정을 자동화 하였습니다.

### 상세
해당 환경실행을 위한 제반 민감정보들은 모두, `githubSecrets` 에 등록하여서 실행시점에 주입받도록 하였습니다.

 처음에는 `github actions`를 통해 jar 파일을 빌드해 `S3`에 업로드하고 `AWS Code Deploy`를 통해 `EC2`에 배포하는 `CI/CD `환경을 구축하려 하였으나, 서버구조가 다중화 되었을 경우, 다중화한 매 `EC2` 서버의 환경을 맞추고, `Code Deploy`를 설정해주고 배포하는 것은 개발 효율성을 떨어트릴거 같아서 OS와 `isolated` 된 환경을 제공해주는 도커를 사용해 보았습니다.

추가적으로 cicd 라는 브랜치에 push 될 경우에도 동작하도록 하였으니, 추가 배포 설정 작업이 필요할 경우 해당 브랜치를 이용하도록 하였습니다.