### PR TITLE
➕ [feat] : 스웨거 문서화 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.swig'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -30,6 +30,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//스웨거
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swig/zigzzang/global/swagger/Swagger.java
+++ b/src/main/java/com/swig/zigzzang/global/swagger/Swagger.java
@@ -1,0 +1,27 @@
+package com.swig.zigzzang.global.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "직짱건강",
+                description = "zigzzang API 명세서 입니다.",
+                version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class Swagger {
+    //http://localhost:8080/swagger-ui/index.html#/
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("직짱건강 API v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+}


### PR DESCRIPTION
### 요약
스웨거 를 통해서 API 문서화 할수 있도록 만들었습니다.

### 상세
저희 프론트와 협업을 위해서 스웨거 자료를 기반으로 API를 설계하면 커뮤니케이션이 서로 원활할것 같아서 해당 기능을 추가해 보았습니다 ! 사용법은 만든 컨트롤러 위에 
```java
    @Operation(summary = "api  제목", description = "해당 api 설명.")


```
을 추가하면 스웨거 문서에도 반영이 됩니다 ! ㅎㅎ