### PR TITLE
➕ [Feat] :  로그인시 JWT 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.swig'
-version = '0.0.2-SNAPSHOT'
+version = '0.0.3-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
@@ -33,6 +33,12 @@ dependencies {
 
 	//스웨거
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+
+	//jwt 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swig/zigzzang/global/security/CustomUserDetails.java
+++ b/src/main/java/com/swig/zigzzang/global/security/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.swig.zigzzang.global.security;
+
+import com.swig.zigzzang.member.Member;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+
+        this.member = member;
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return member.getUserId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/global/security/CutomUserDetailsService.java
+++ b/src/main/java/com/swig/zigzzang/global/security/CutomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.swig.zigzzang.global.security;
+
+import com.swig.zigzzang.member.Member;
+import com.swig.zigzzang.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CutomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+
+    public CutomUserDetailsService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByUserId(username);
+
+
+        if (member != null) {
+
+            return new CustomUserDetails(member);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -1,0 +1,65 @@
+package com.swig.zigzzang.global.security;
+
+import com.swig.zigzzang.member.Member;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JWTFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+
+        this.jwtUtil = jwtUtil;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorization= request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+            return;
+
+        }
+
+        System.out.println("authorization now");
+        String token = authorization.split(" ")[1];
+
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("AccessToken 기간만료");
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        String username = jwtUtil.getUserId(token);
+        String password = jwtUtil.getPassword(token);
+
+        Member member = Member.builder()
+                .userId(username)
+
+                .password(password)
+                .build();
+        CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -1,0 +1,88 @@
+package com.swig.zigzzang.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JWTUtil {
+    public static final String BEARER_TYPE = "Bearer";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_HEADER = "RefreshToken";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Autowired
+    private RedisService redisService;
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUserId(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userid", String.class);
+    }
+
+    public String getPassword(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("password", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String userid, String password, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("userid", userid)
+                .claim("password", password)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+    public String createRefreshToken(String userid, String password, Long expiredMs) {
+
+
+        String refreshToken = Jwts.builder()
+                .claim("userid", userid)
+                .claim("password", password)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+
+        // redis에 RT저장
+        redisService.setValues(userid,refreshToken);
+
+        return refreshToken;
+    }
+    // Request Header에 Access Token 정보를 추출하는 메서드
+    public String getAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // Request Header에 Refresh Token 정보를 추출하는 메서드
+    public String getRefreshToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(REFRESH_HEADER);
+        if (StringUtils.hasText(bearerToken)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.swig.zigzzang.global.security;
 
+import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -17,8 +18,7 @@ public class JWTUtil {
     public static final String REFRESH_HEADER = "RefreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
 
-    @Autowired
-    private RedisService redisService;
+
     private SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
@@ -63,8 +63,6 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
 
-        // redis에 RT저장
-        redisService.setValues(userid,refreshToken);
 
         return refreshToken;
     }

--- a/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
@@ -1,0 +1,64 @@
+package com.swig.zigzzang.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+
+    private final JWTUtil jwtUtil;
+
+
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
+
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil=jwtUtil;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        //클라이언트 요청에서 username, password 추출
+        String username = obtainUsername(request);
+        String password = obtainPassword(request);
+        logger.info("추출한 username : "+username);
+        logger.info("추출한 비밀번호 : "+password);
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+
+        //UserDetailsS
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+
+        String password = customUserDetails.getPassword();
+        //AT : 6분
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
+        //RT : 7일
+        String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
+
+
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("RefreshToken","Bearer "+refreshToken);
+
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/MainController.java
+++ b/src/main/java/com/swig/zigzzang/global/security/MainController.java
@@ -1,0 +1,21 @@
+package com.swig.zigzzang.global.security;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+public class MainController {
+    @GetMapping("/userinfo")
+    @Operation
+    public String main() {
+        String username= SecurityContextHolder.getContext().getAuthentication()
+                .getName();
+
+
+        return "현재 접속자 아이디 : "+username;
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.swig.zigzzang.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    private final JWTUtil jwtUtil;
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration,JWTUtil jwtUtil) {
+
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //http basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/**").permitAll()
+                        .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        //스웨거 접근권한 허용
+                        .anyRequest().authenticated());
+
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+
+
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+
+        //세션 설정
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
+++ b/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.swig.zigzzang.member.repository;
+
+import com.swig.zigzzang.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findByUserId(String username);
+}


### PR DESCRIPTION
### 요약 
로그인시 사용자 정보를 조회하여 검증하고, `JWT` 를 하고 발급하는 기능을 구현하였습니다. 

### 상세
회원가입 과정시 DTO인 MemberJoinRequest의 필수 필드값이 빠져있을 경우, `MethodArgumentNotValidException.class` 예외가  발생되도록 구현하였습니다. 
해당 예외는 로그인 기능 완성후 커스텀 예외 처리 할때 handler 생성후 처리할 예정입니다.
회원가입이 성공하면 회원의 비밀번호는  `BCryptPasswordEncoder` 를 통하여 암호화된채로 DB에 저장되도록 구현하였습니다. 

해당 방법이 `SpringSecurity 6.0 `부터 공식적으로 추천하는 옵션이라서 해당 암호화 기법을 사용하였습니다.
또한 로그인 성공시 AT의 유효시간은 36000MS 로 설정하였고, 토큰속에는 사용자의 아이디와 비밀번호를 담도록 설계하였습니다.
현재는 토큰 발급 기능까지 구현하였고 추가적으로 발급된 토큰을 Resolve하는 JWT 검증 기능을 구현할 예정입니다. 
 또한 로그인 할 경우 `AccessToken` (기한 5분) 과 `RefreshToken`(기한 7일) 의 `JWT`를 발행하도록 구현하였습니다. 클라이언트에서 이 토큰들을 헤더에 포함하여, api 요청하면 토큰 유무에 따라 status 코드를 다르게 구현할 예정입니다. ! 