### PR TITLE
➕ [Feat] : BaseResponse 통신 규약 정의 및 커스텀 Exception 설정

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -1,0 +1,13 @@
+package com.swig.zigzzang.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HttpExceptionCode {;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swig/zigzzang/global/response/ApiResponse.java
+++ b/src/main/java/com/swig/zigzzang/global/response/ApiResponse.java
@@ -1,0 +1,4 @@
+package com.swig.zigzzang.global.response;
+
+public record ApiResponse<T>(String success, T data) {
+}

--- a/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
+++ b/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.swig.zigzzang.global.response;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(HttpStatus errCode, String message) {
+    public static ErrorResponse from(HttpExceptionCode exceptionCode) {
+        return new ErrorResponse(exceptionCode.getHttpStatus(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse from(HttpExceptionCode exceptionCode, String errorMessage) {
+        return new ErrorResponse(exceptionCode.getHttpStatus(), errorMessage);
+    }
+
+    public static ErrorResponse from(HttpStatus httpStatus, String errorMessage) {
+        return new ErrorResponse(httpStatus, errorMessage);
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
+++ b/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
@@ -3,17 +3,17 @@ package com.swig.zigzzang.global.response;
 import com.swig.zigzzang.global.exception.HttpExceptionCode;
 import org.springframework.http.HttpStatus;
 
-public record ErrorResponse(HttpStatus errCode, String message) {
+public record ErrorResponse(String success, String message) {
     public static ErrorResponse from(HttpExceptionCode exceptionCode) {
-        return new ErrorResponse(exceptionCode.getHttpStatus(), exceptionCode.getMessage());
+        return new ErrorResponse("false", exceptionCode.getMessage());
     }
 
     public static ErrorResponse from(HttpExceptionCode exceptionCode, String errorMessage) {
-        return new ErrorResponse(exceptionCode.getHttpStatus(), errorMessage);
+        return new ErrorResponse("false", errorMessage);
     }
 
     public static ErrorResponse from(HttpStatus httpStatus, String errorMessage) {
-        return new ErrorResponse(httpStatus, errorMessage);
+        return new ErrorResponse("false", errorMessage);
     }
 
 }

--- a/src/main/java/com/swig/zigzzang/global/response/HttpResponse.java
+++ b/src/main/java/com/swig/zigzzang/global/response/HttpResponse.java
@@ -1,0 +1,28 @@
+package com.swig.zigzzang.global.response;
+
+import org.apache.catalina.connector.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+
+public class HttpResponse<T> extends ResponseEntity<ApiResponse<T>> {
+
+    public static <T> HttpResponse<T> okBuild(T body) {
+        return new HttpResponse<>(HttpStatus.OK, body);
+    }
+
+    public HttpResponse(HttpStatusCode status) {
+        super(status);
+    }
+
+    public HttpResponse(ApiResponse<T> body, HttpStatusCode status) {
+        super(body, status);
+    }
+    public HttpResponse(HttpStatusCode status, T data) {
+        super(new ApiResponse<>("true", data), status);
+    }
+
+
+
+}

--- a/src/main/java/com/swig/zigzzang/global/security/MainController.java
+++ b/src/main/java/com/swig/zigzzang/global/security/MainController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @ResponseBody
 public class MainController {
     @GetMapping("/userinfo")
-    @Operation
+
     public String main() {
         String username= SecurityContextHolder.getContext().getAuthentication()
                 .getName();

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.swig.zigzzang.member.controller;
 
+import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.dto.MemberJoinResponse;
 import com.swig.zigzzang.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +21,11 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public ResponseEntity<MemberJoinResponse> join(@Valid @RequestBody MemberJoinRequest memberJoinRequest) {
+    @Operation(summary = "회원가입", description = "회원가입을 실행합니다.")
+
+    public HttpResponse<MemberJoinResponse> join(@Valid @RequestBody MemberJoinRequest memberJoinRequest) {
         Member savedmember = memberService.save(memberJoinRequest);
-        return ResponseEntity.ok(
+        return HttpResponse.okBuild(
                 MemberJoinResponse.of(savedmember)
         );
     }

--- a/src/main/java/com/swig/zigzzang/member/dto/MemberJoinResponse.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/MemberJoinResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record MemberJoinResponse(
-        Long id, String userid,String password,String email,String nickname
+        String surveyUrl,String message
 
 
 ) {
@@ -13,11 +13,8 @@ public record MemberJoinResponse(
 
     public static MemberJoinResponse of(Member member) {
         return MemberJoinResponse.builder()
-                .id(member.getMemberId())
-                .userid(member.getUserId())
-                .email(member.getEmail())
-                .password(member.getPassword())
-                .nickname(member.getNickname())
+                .message(member.getNickname()+"님 회원가입을 축하합니다 !")
+                .surveyUrl("example.com")
                 .build();
 
     }


### PR DESCRIPTION
우리 서비스의 BaseResponse를 설계하였습니다. 
세부 포맷은 
``` json
{
    "success": true,
    "data": {
        //DTO의 내용
    }
}
```
으로 했습니다. 실제 컨트롤러에서 전송하는 클래스는 `ResponseEntity<ApiContent<T>>`를 상속받는 HttpResponse로 구현하였고, 빌더 패턴으로 Status Code별로 생성되도록 구현하면 좋을거 같아서 예시로 OK 200 코드를 만들어 보았습니다.

추가로 DTO는 해당 Api 테스트 용도로 네트워크 health체크 컨트롤러로 테스트 완료하였습니다.
각 DTO 별로 **정적팩토리** 매서드인 `from`을 적용해 보았습니다. `네이밍 컨벤션`은 
```
from : 하나의 매개 변수를 받아서 객체를 생성
of : 여러개의 매개 변수를 받아서 객체를 생성
getInstance | instance : 인스턴스를 생성. 이전에 반환했던 것과 같을 수 있음
newInstance | create : 항상 새로운 인스턴스를 생성
get[OrderType] : 다른 타입의 인스턴스를 생성. 이전에 반환했던 것과 같을 수 있음
new[OrderType] : 항상 다른 타입의 새로운 인스턴스를 생성

``` 
을 따르면 좋을거 같습니다 !! ㅎㅎ 