### PR TITLE
➕ [feat] : CORS 허용 기능 구현

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/security/CorsMvcConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/CorsMvcConfig.java
@@ -1,0 +1,16 @@
+package com.swig.zigzzang.global.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@Configuration
+
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .allowedOrigins("*");
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.swig.zigzzang.global.security;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -10,6 +12,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -41,6 +45,28 @@ public class SecurityConfig {
         //csrf disable
         http
                 .csrf((auth) -> auth.disable());
+
+        //cors 설정
+        http
+                .cors((corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList("*"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                })));
+
 
         //From 로그인 방식 disable
         http

--- a/src/main/java/com/swig/zigzzang/global/security/WebConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/WebConfig.java
@@ -1,0 +1,30 @@
+package com.swig.zigzzang.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.addAllowedOrigin("*");
+
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        config.setAllowCredentials(false);
+
+        config.setMaxAge(6000L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
### 요약
`CORS` 교차 출처 리소스 공유 제한을 해제하였습니다.


### 상세

스프링 커스텀 필터와 시큐리티 필터의 설정을 통하여 `CORS`  제한을 해재하였습니다. 현제는 개발단계라 `"*"` 와일드카드로 하였지만, 추후에 도메인이 정해지면, 해당 도메인만 허용되도록 수정할 예정입니다.