### PR TITLE
➕ [Feat] : 커스텀 예외 및 핸들러 구현

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum HttpExceptionCode {
     UNABLE_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST, "이메일 전송에 실패했습니다."),
-    MEMBER_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 회원입니다.");
+    MEMBER_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum HttpExceptionCode {
     UNABLE_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST, "이메일 전송에 실패했습니다."),
     MEMBER_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT를 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
 

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/BuisnessException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/BuisnessException.java
@@ -1,0 +1,19 @@
+package com.swig.zigzzang.global.exception.custom;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+public class BuisnessException {
+    @Getter
+    public class BusinessException extends RuntimeException {
+
+        private final HttpStatus httpStatus;
+
+        public BusinessException(HttpExceptionCode httpExceptionCode) {
+            super(httpExceptionCode.getMessage());
+            this.httpStatus = httpExceptionCode.getHttpStatus();
+        }
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/security/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/security/RefreshTokenNotFoundException.java
@@ -1,0 +1,24 @@
+package com.swig.zigzzang.global.exception.custom.security;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Slf4j
+public class RefreshTokenNotFoundException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public RefreshTokenNotFoundException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public RefreshTokenNotFoundException() {
+        this(HttpExceptionCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/security/SecurityJwtNotFoundException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/security/SecurityJwtNotFoundException.java
@@ -1,0 +1,22 @@
+package com.swig.zigzzang.global.exception.custom.security;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Slf4j
+public class SecurityJwtNotFoundException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    public SecurityJwtNotFoundException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus=exceptionCode.getHttpStatus();
+    }
+
+
+    public SecurityJwtNotFoundException(){
+        this(HttpExceptionCode.JWT_NOT_FOUND);}
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.swig.zigzzang.global.exception.handler;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import com.swig.zigzzang.global.response.ErrorResponse;
+import com.swig.zigzzang.global.response.HttpResponse;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public HttpResponse<ErrorResponse> businessExceptionHandle(BusinessException e) {
+        log.warn("businessException : {}", e);
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> allUncaughtHandle(Exception e) {
+        log.error("allUncaughtHandle : {}", e);
+        return ResponseEntity.internalServerError().body(e.getMessage());
+    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected HttpResponse<ErrorResponse> methodArgumentNotValidExceptionHandle(MethodArgumentNotValidException e) {
+        log.error("methodArgumentNotValidException : {}", e);
+
+        BindingResult bindingResult = e.getBindingResult();
+
+        String errorMessage = bindingResult.getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining());
+
+        return HttpResponse.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.from(HttpExceptionCode.INVALID_ARGUMENT.getHttpStatus(), errorMessage));
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.swig.zigzzang.global.exception.handler;
 
 import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import com.swig.zigzzang.global.exception.custom.BuisnessException.BusinessException;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import java.util.stream.Collectors;

--- a/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
+++ b/src/main/java/com/swig/zigzzang/global/response/ErrorResponse.java
@@ -3,17 +3,17 @@ package com.swig.zigzzang.global.response;
 import com.swig.zigzzang.global.exception.HttpExceptionCode;
 import org.springframework.http.HttpStatus;
 
-public record ErrorResponse(String success, String message) {
+public record ErrorResponse(HttpStatus errCode, String message) {
     public static ErrorResponse from(HttpExceptionCode exceptionCode) {
-        return new ErrorResponse("false", exceptionCode.getMessage());
+        return new ErrorResponse(exceptionCode.getHttpStatus(), exceptionCode.getMessage());
     }
 
     public static ErrorResponse from(HttpExceptionCode exceptionCode, String errorMessage) {
-        return new ErrorResponse("false", errorMessage);
+        return new ErrorResponse(exceptionCode.getHttpStatus(), errorMessage);
     }
 
     public static ErrorResponse from(HttpStatus httpStatus, String errorMessage) {
-        return new ErrorResponse("false", errorMessage);
+        return new ErrorResponse(httpStatus, errorMessage);
     }
 
 }


### PR DESCRIPTION
### 요약 
1. 프로젝트의 커스텀 익셉션을 형식과 규칙을 정의하였습니다 ! 
2. 커스텀 익셉션의 핸들러를 정의했습니다 !

### 상세
우선적으로 세부 도메인 이 아닌 `Global` 하게 일어나는 예외를 정의하였습니다. 또한 `Error`를 반환할 `BaseResponse` 또한 정의하였습니다. 특히 `BuisinessException`은 단순 `RuntimeException`을 상속 받는 것으로, `RunTimeException`과 동일하게 생각하면 됩니다 ! ㅎㅎ 이렇게 상속받은 이유는 아무래도 가독성 측면에서 비즈니스 로직에서 발생한 예외라는 것을 명시적으로 드러내기  좋아서 그렇게 하였습니다 !! ㅎㅎ 커스텀으로 예외처리 하지 않은 모든 `Runtime` 예외는 `GlobalExceptionHandler`에서 처리하도록 하였습니다. 
```java 
 @ExceptionHandler(BusinessException.class)
    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
    public HttpResponse<ErrorResponse> businessExceptionHandle(BusinessException e) {
        log.warn("businessException : {}", e);
        return HttpResponse.status(e.getHttpStatus())
                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
    }
```