### PR TITLE
➕[Feat] : Redis 에 RefreshToken 저장 기능 구현

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -13,7 +13,8 @@ public enum HttpExceptionCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다.");
+    NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다."),
+    USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -12,7 +12,8 @@ public enum HttpExceptionCode {
     JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT를 찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/security/CutomUserDetailsService.java
+++ b/src/main/java/com/swig/zigzzang/global/security/CutomUserDetailsService.java
@@ -2,6 +2,7 @@ package com.swig.zigzzang.global.security;
 
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.repository.MemberRepository;
+import java.util.Optional;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -21,12 +22,13 @@ public class CutomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-        Member member = memberRepository.findByUserId(username);
+        Optional<Member> member = memberRepository.findByUserId(username);
+
 
 
         if (member != null) {
 
-            return new CustomUserDetails(member);
+            return new CustomUserDetails(member.get());
         }
 
         return null;

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.swig.zigzzang.global.security;
 
+import com.swig.zigzzang.global.redis.RedisService;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
@@ -17,7 +18,8 @@ public class JWTUtil {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String REFRESH_HEADER = "RefreshToken";
     public static final String BEARER_PREFIX = "Bearer ";
-
+    @Autowired
+    private RedisService redisService;
 
     private SecretKey secretKey;
 
@@ -62,6 +64,8 @@ public class JWTUtil {
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
+        // redis에 RT저장
+        redisService.setValues(refreshToken,userid);
 
 
         return refreshToken;

--- a/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.swig.zigzzang.global.security;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -53,6 +54,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.addHeader("Authorization", "Bearer " + accessToken);
         response.addHeader("RefreshToken","Bearer "+refreshToken);
+        Cookie cookie = createCookie(refreshToken);
+        response.addCookie(cookie);
+
 
     }
 
@@ -60,5 +64,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
 
         response.setStatus(401);
+    }
+    public Cookie createCookie(String refreshToken) {
+        String cookieName = "refreshtoken";
+        String cookieValue = refreshToken;
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24 * 7);
+
+        return cookie;
     }
 }

--- a/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
@@ -4,6 +4,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -37,7 +39,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     }
 
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication)
+            throws UnsupportedEncodingException {
 
         //UserDetailsS
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
@@ -65,9 +68,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.setStatus(401);
     }
-    public Cookie createCookie(String refreshToken) {
+    public Cookie createCookie(String refreshToken) throws UnsupportedEncodingException {
         String cookieName = "refreshtoken";
-        String cookieValue = "Bearer "+refreshToken;
+        String cookieValue = refreshToken;
         Cookie cookie = new Cookie(cookieName, cookieValue);
 
         cookie.setHttpOnly(true);

--- a/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
@@ -67,7 +67,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     }
     public Cookie createCookie(String refreshToken) {
         String cookieName = "refreshtoken";
-        String cookieValue = refreshToken;
+        String cookieValue = "Bearer "+refreshToken;
         Cookie cookie = new Cookie(cookieName, cookieValue);
 
         cookie.setHttpOnly(true);

--- a/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                         configuration.setMaxAge(3600L);
 
                         configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+                        configuration.setExposedHeaders(Collections.singletonList("RefreshToken"));
 
                         return configuration;
                     }

--- a/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
@@ -1,6 +1,7 @@
 package com.swig.zigzzang.member.exception;
 
 import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import com.swig.zigzzang.member.domain.Member;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -19,5 +20,10 @@ public class MemberExistException extends RuntimeException{
 
     public MemberExistException() {
         this(HttpExceptionCode.MEMBER_EXISTS);
+    }
+
+    public MemberExistException(Member member) {
+        this(HttpExceptionCode.MEMBER_EXISTS);
+
     }
 }

--- a/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
@@ -22,8 +22,5 @@ public class MemberExistException extends RuntimeException{
         this(HttpExceptionCode.MEMBER_EXISTS);
     }
 
-    public MemberExistException(Member member) {
-        this(HttpExceptionCode.MEMBER_EXISTS);
 
-    }
 }

--- a/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/MemberExistException.java
@@ -16,4 +16,8 @@ public class MemberExistException extends RuntimeException{
         super(exceptionCode.getMessage());
         this.httpStatus = exceptionCode.getHttpStatus();
     }
+
+    public MemberExistException() {
+        this(HttpExceptionCode.MEMBER_EXISTS);
+    }
 }

--- a/src/main/java/com/swig/zigzzang/member/exception/NickNameAlreadyExistException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/NickNameAlreadyExistException.java
@@ -1,0 +1,17 @@
+package com.swig.zigzzang.member.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public class NickNameAlreadyExistException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public NickNameAlreadyExistException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public NickNameAlreadyExistException() {
+        this(HttpExceptionCode.NICKNAME_EXIST);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/UserIdAlreadyExistException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/UserIdAlreadyExistException.java
@@ -1,21 +1,19 @@
 package com.swig.zigzzang.member.exception;
 
 import com.swig.zigzzang.global.exception.HttpExceptionCode;
-import com.swig.zigzzang.member.domain.Member;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class NickNameAlreadyExistException extends RuntimeException{
+public class UserIdAlreadyExistException extends RuntimeException{
     private final HttpStatus httpStatus;
 
-    public NickNameAlreadyExistException(HttpExceptionCode exceptionCode) {
+    public UserIdAlreadyExistException(HttpExceptionCode exceptionCode) {
         super(exceptionCode.getMessage());
         this.httpStatus = exceptionCode.getHttpStatus();
     }
 
-    public NickNameAlreadyExistException() {
-        this(HttpExceptionCode.NICKNAME_EXIST);
+    public UserIdAlreadyExistException() {
+        this(HttpExceptionCode.USERID_EXIST);
     }
-
 }

--- a/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
@@ -3,6 +3,8 @@ package com.swig.zigzzang.member.exception.handler;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.member.exception.MemberExistException;
+import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
+import com.swig.zigzzang.member.exception.UserIdAlreadyExistException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -19,6 +21,19 @@ public class MemberExceptionHandler {
     @ExceptionHandler(MemberExistException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ResponseEntity<ErrorResponse> memberExistExceptionHandler(MemberExistException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    // New handler for NickNameAlreadyExistException
+    @ExceptionHandler(NickNameAlreadyExistException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<ErrorResponse> nickNameAlreadyExistExceptionHandler(NickNameAlreadyExistException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    @ExceptionHandler(UserIdAlreadyExistException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<ErrorResponse> userIdAlreadyExistExceptionHandler(UserIdAlreadyExistException e) {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }

--- a/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
+++ b/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Member findByUserId(String username);
+    Optional<Member> findByUserId(String username);
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -55,7 +55,6 @@ public class MemberService {
         String title = "직짱건강 이메일 인증 번호";
         String authCode = this.createCode();
         mailService.sendEmail(toEmail, title, authCode);
-        // 이메일 인증 요청 시 인증 번호 Redis에 저장 ( key = "AuthCode " + Email / value = AuthCode )
         redisService.setValues(AUTH_CODE_PREFIX + toEmail,
                 authCode, Duration.ofMillis(this.authCodeExpirationMillis));
     }
@@ -77,7 +76,6 @@ public class MemberService {
             }
             return builder.toString();
         } catch (NoSuchAlgorithmException e) {
-            log.debug("MemberService.createCode() exception occur");
             throw new MemberExistException(HttpExceptionCode.MEMBER_EXISTS);
         }
     }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.exception.MemberExistException;
 import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
+import com.swig.zigzzang.member.exception.UserIdAlreadyExistException;
 import com.swig.zigzzang.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import java.security.NoSuchAlgorithmException;
@@ -40,10 +41,14 @@ public class MemberService {
         Member member = memberJoinRequest.toEntity();
 
         member.setPassword(bCryptPasswordEncoder.encode(member.getPassword()));
-        memberRepository.findByUserId(member.getUserId())
-                .ifPresent( MemberExistException::new);
-        memberRepository.findByNickname(member.getNickname())
-                .orElseThrow(NickNameAlreadyExistException::new);
+        Optional<Member> userId = memberRepository.findByUserId(member.getUserId());
+        if (userId.isPresent()) {
+            throw new UserIdAlreadyExistException();
+        }
+        Optional<Member> nickname = memberRepository.findByNickname(member.getNickname());
+        if (nickname.isPresent()) {
+            throw new NickNameAlreadyExistException();
+        }
 
         Member savedmember = memberRepository.save(member);
 

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.swig.zigzzang.global.redis.RedisService;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.exception.MemberExistException;
+import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
 import com.swig.zigzzang.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import java.security.NoSuchAlgorithmException;
@@ -39,6 +40,10 @@ public class MemberService {
         Member member = memberJoinRequest.toEntity();
 
         member.setPassword(bCryptPasswordEncoder.encode(member.getPassword()));
+        memberRepository.findByUserId(member.getUserId())
+                .orElseThrow(MemberExistException::new);
+        memberRepository.findByNickname(member.getNickname())
+                .orElseThrow(NickNameAlreadyExistException::new);
 
         Member savedmember = memberRepository.save(member);
 

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
 
         member.setPassword(bCryptPasswordEncoder.encode(member.getPassword()));
         memberRepository.findByUserId(member.getUserId())
-                .orElseThrow(MemberExistException::new);
+                .ifPresent( MemberExistException::new);
         memberRepository.findByNickname(member.getNickname())
                 .orElseThrow(NickNameAlreadyExistException::new);
 


### PR DESCRIPTION
### 요약
1. 발급한 `refreshToken`을` Http Only Cookie`를 통해 클라이언트로 반환하는 기능을 구현하였습니다.
2. 반환한 `refreshToken`을 `redis` 저장 하는 기능을 구현하였습니다.

### 상세
우선 리프레시토큰은 앞전에 발행한 `AccessToken` 과 달리 7일을 주기로 발급하도록 구현하였고, 해당 발급 토큰 모두 `Http` 응답값의 `header`에 넣은채로 반환되도록 구현하였습니다. 

 또한 만약 만기가 긴 `refreshtoken`이 탈취될 경우를 대비하여 서버에서  제어 가능해야 함으로, 서버에 저장하는 방법을 택했습니다.  해더에 넣은 이유는  `Body`보다는 `header`에 넣는 **관습**(컨벤션) 이 있다 하여서 그렇게 구현하였습니다.
또한 만기간 긴 `refreshtoken`은 헤더가 아닌 **HttpOnlyCookie**에 넣어서 반환함으로써 `Javscript`의 `Document.cookieAPI`로 접근이 불가능하도록 구현하였습니다. 따라서 XSS 취약점 공격으로 담긴 값을 불러올 수 없게 하였습니다. 

  **RDB**에 저장하는것이 아닌 **레디스**를 선택한 이유는  I/O가 빈번한 데이터를 저장할 때 사용하기 좋다는 점과 운영 중인 웹 서버에서 `key-value` 형태의 데이터 타입을 처리해야 할 때 사용하기 적합하기 때문에 선택하였습니다.


   `key-value` 값 발행당시 사용자 아이디와 리프레시토큰을 저장하도록 구현하였습니다. 

![image](https://github.com/SWYP-3rd-period-1-team/zigzzang-backend/assets/58305106/89f29566-0b47-41b1-aeba-260a6f46b51b)


---
 
### 추후 개발 사항 

1. 로그아웃시 레디스 에 저장된 `refreshtoken`을 블랙리스트 처리하는 방식을 고려중입니다.
2. 보안점으로, 래디스에 저장된 **토큰 자체**가 탈취당할 경우 대응방안을 마련할 예정입니다.. 