### PR TITLE
➕ [Feat] : 레디스를 이용한 로그아웃, 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -14,7 +14,8 @@ public enum HttpExceptionCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다."),
-    USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다.");
+    USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다."),
+    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -15,7 +15,7 @@ public enum HttpExceptionCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다."),
     USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다."),
-    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다.");
+    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다. 기한이 만료되었거나, 이미 로그아웃이 완료되어 DB에 존재하지 않는 상태입니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/security/IncorrectRefreshTokenException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/security/IncorrectRefreshTokenException.java
@@ -1,0 +1,20 @@
+package com.swig.zigzzang.global.exception.custom.security;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+@Getter
+@Setter
+public class IncorrectRefreshTokenException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public IncorrectRefreshTokenException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public IncorrectRefreshTokenException() {
+        this(HttpExceptionCode.INCORRECT_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.swig.zigzzang.global.exception.handler.security;
+
+
+import com.swig.zigzzang.global.exception.custom.security.IncorrectRefreshTokenException;
+import com.swig.zigzzang.global.exception.custom.security.RefreshTokenNotFoundException;
+import com.swig.zigzzang.global.exception.custom.security.SecurityJwtNotFoundException;
+import com.swig.zigzzang.global.response.ErrorResponse;
+import com.swig.zigzzang.global.response.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SecurityExceptionHandler {
+
+    @ExceptionHandler(SecurityJwtNotFoundException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public HttpResponse<ErrorResponse> securityExceptionHandler(SecurityJwtNotFoundException e) {
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+
+    }
+    @ExceptionHandler(RefreshTokenNotFoundException.class)  // 새로운 예외 핸들러 추가
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public HttpResponse<ErrorResponse> refreshTokenNotFoundExceptionHandler(RefreshTokenNotFoundException e) {
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    @ExceptionHandler(IncorrectRefreshTokenException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public HttpResponse<ErrorResponse> incorrectRefreshTokenExceptionHandler(IncorrectRefreshTokenException e) {
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+}

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -4,6 +4,7 @@ import com.swig.zigzzang.global.redis.RedisService;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -65,7 +66,7 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
         // redis에 RT저장
-        redisService.setValues(refreshToken,userid);
+        redisService.setValues(refreshToken,userid, Duration.ofMillis(expiredMs));
 
 
         return refreshToken;

--- a/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/security/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/api/members/join","api/members/refresh","/login").permitAll()
                         .requestMatchers("/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         //스웨거 접근권한 허용

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.dto.MemberJoinResponse;
+import com.swig.zigzzang.member.dto.TokenRefreshRequest;
+import com.swig.zigzzang.member.dto.TokenRefreshResponse;
 import com.swig.zigzzang.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -31,6 +33,14 @@ public class MemberController {
         Member savedmember = memberService.save(memberJoinRequest);
         return HttpResponse.okBuild(
                 MemberJoinResponse.of(savedmember)
+        );
+    }
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 갱신", description = "만료된 AccessToken을 RefreshToken을 사용해 갱신합니다.")
+    public HttpResponse<TokenRefreshResponse> refreshToken(@RequestBody TokenRefreshRequest refreshRequest) {
+        String newAccessToken = memberService.refreshToken(refreshRequest.refreshToken());
+        return HttpResponse.okBuild(
+                TokenRefreshResponse.of(newAccessToken)
         );
     }
 

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -2,18 +2,23 @@ package com.swig.zigzzang.member.controller;
 
 import com.swig.zigzzang.email.dto.EmailResponseDto;
 import com.swig.zigzzang.global.response.HttpResponse;
+import com.swig.zigzzang.global.security.JWTUtil;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.dto.MemberJoinResponse;
+import com.swig.zigzzang.member.dto.MemberLogoutResponse;
 import com.swig.zigzzang.member.dto.TokenRefreshRequest;
 import com.swig.zigzzang.member.dto.TokenRefreshResponse;
 import com.swig.zigzzang.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/join")
     @Operation(summary = "회원가입", description = "회원가입을 실행합니다.")
@@ -36,11 +42,25 @@ public class MemberController {
         );
     }
     @PostMapping("/refresh")
-    @Operation(summary = "토큰 갱신", description = "만료된 AccessToken을 RefreshToken을 사용해 갱신합니다.")
+    @Operation(summary = "AccessToken 갱신", description = "만료된 AccessToken을 RefreshToken을 사용해 갱신합니다.")
     public HttpResponse<TokenRefreshResponse> refreshToken(@RequestBody TokenRefreshRequest refreshRequest) {
         String newAccessToken = memberService.refreshToken(refreshRequest.refreshToken());
         return HttpResponse.okBuild(
                 TokenRefreshResponse.of(newAccessToken)
+        );
+    }
+    @PatchMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃을 요청하여 RfreshToken을 블랙처리 합니다.")
+
+    public HttpResponse<MemberLogoutResponse> logout(HttpServletRequest request) {
+
+        String username= SecurityContextHolder.getContext().getAuthentication()
+                .getName();
+        String encryptedRefreshToken = jwtUtil.getRefreshToken(request);
+        String blacklist = memberService.logout(encryptedRefreshToken);
+
+        return HttpResponse.okBuild(
+                MemberLogoutResponse.from(username,blacklist)
         );
     }
 

--- a/src/main/java/com/swig/zigzzang/member/dto/MemberLogoutResponse.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/MemberLogoutResponse.java
@@ -1,0 +1,15 @@
+package com.swig.zigzzang.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MemberLogoutResponse(String message,String blacklist) {
+    public static MemberLogoutResponse from(String username,String blacklist){
+
+        return MemberLogoutResponse.builder()
+                .message("요청하신 " + username + " 의 리프레시토큰이 블랙리스트 처리되었습니다."
+                        + " 새롭게 로그인후 RT,AT를 발급받아주세요")
+                .blacklist(blacklist)
+                .build();
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/TokenRefreshRequest.java
@@ -1,0 +1,5 @@
+package com.swig.zigzzang.member.dto;
+
+public record TokenRefreshRequest(String refreshToken) {
+
+}

--- a/src/main/java/com/swig/zigzzang/member/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/TokenRefreshResponse.java
@@ -1,0 +1,7 @@
+package com.swig.zigzzang.member.dto;
+
+public record TokenRefreshResponse(String accessToken) {
+    public static TokenRefreshResponse of(String accessToken) {
+        return new TokenRefreshResponse(accessToken);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/MemberNotFoundException.java
@@ -1,0 +1,19 @@
+package com.swig.zigzzang.member.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+public class MemberNotFoundException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public MemberNotFoundException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public MemberNotFoundException() {
+        this(HttpExceptionCode.USER_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
@@ -25,7 +25,6 @@ public class MemberExceptionHandler {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }
-    // New handler for NickNameAlreadyExistException
     @ExceptionHandler(NickNameAlreadyExistException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ResponseEntity<ErrorResponse> nickNameAlreadyExistExceptionHandler(NickNameAlreadyExistException e) {
@@ -38,7 +37,7 @@ public class MemberExceptionHandler {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }
-    @ExceptionHandler(MemberNotFoundException.class) // 새로운 예외에 대한 핸들러 추가
+    @ExceptionHandler(MemberNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ResponseEntity<ErrorResponse> memberNotFoundExceptionHandler(MemberNotFoundException e) {
         return ResponseEntity.status(e.getHttpStatus())

--- a/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
@@ -3,6 +3,7 @@ package com.swig.zigzzang.member.exception.handler;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.member.exception.MemberExistException;
+import com.swig.zigzzang.member.exception.MemberNotFoundException;
 import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
 import com.swig.zigzzang.member.exception.UserIdAlreadyExistException;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,12 @@ public class MemberExceptionHandler {
     @ExceptionHandler(UserIdAlreadyExistException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ResponseEntity<ErrorResponse> userIdAlreadyExistExceptionHandler(UserIdAlreadyExistException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    @ExceptionHandler(MemberNotFoundException.class) // 새로운 예외에 대한 핸들러 추가
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse> memberNotFoundExceptionHandler(MemberNotFoundException e) {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -139,7 +139,7 @@ public class MemberService {
         String blacklistKey = encryptedRefreshToken;
 
 
-        redisService.setValues(blacklistKey, "blacklist");
+        redisService.setValues(blacklistKey, "blacklist",Duration.ofMillis(60*60*100L));
         return "blaklist " + blacklistKey;
     }
     private void isTokenPresent(String encryptedRefreshToken) {


### PR DESCRIPTION
### 요약
1. 로그아웃 요청시 블랙리스트 처리를 통한 `RT` 폐기 기능을 구현하였습니다.
2. `Redis`의 `TTL` 기능 을 이용하여서 주어진 data 만료 기한을 설정 하여 기한만료시 자동으로 DB에서 삭제되는 기능을 구현하였습니다.
3. RT 토큰 재발급 수행시, 레디스에 저장된 RT의 존재유무 판단후 반환 기능 구현하였습니다.


### 상세
`redis`의 `TTL` 기능을 이용하여 유효기간 (7일)이 지나면 자동으로 레디스에서 삭제되도록 구현 하였습니다. 또한 `RTR` 방식을 통해 토큰 재발급시, 동시 재발급으로 보안의 안정성을 높였습니다.