### PR TITLE
➕ [Feat] : 토큰 상태별 예외처리

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -21,7 +21,9 @@ public enum HttpExceptionCode {
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED,"인증 토큰이 존재하지 않습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다."),
     HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Authorization 헤더 정보가 존재하지 않습니다."),
-    BEARER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Bearer 로 Authorization 헤더가 시작되지 않습니다.");
+    BEARER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Bearer 로 Authorization 헤더가 시작되지 않습니다."),
+    EMAIL_FAILED(HttpStatus.UNAUTHORIZED,"이메일 코드가 올바르지 않습니다.");
+
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -19,7 +19,9 @@ public enum HttpExceptionCode {
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"만료된 토큰입니다. 토큰을 재발급하세요"),
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 정보가 임의로 변경되었습니다."),
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED,"인증 토큰이 존재하지 않습니다."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다.");
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다."),
+    HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Authorization 헤더 정보가 존재하지 않습니다.");
+
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -16,7 +16,10 @@ public enum HttpExceptionCode {
     NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다."),
     USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다."),
     INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다. 기한이 만료되었거나, 이미 로그아웃이 완료되어 DB에 존재하지 않는 상태입니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"만료된 토큰입니다. 토큰을 재발급하세요");
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"만료된 토큰입니다. 토큰을 재발급하세요"),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 정보가 임의로 변경되었습니다."),
+    UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED,"인증 토큰이 존재하지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -20,7 +20,8 @@ public enum HttpExceptionCode {
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 정보가 임의로 변경되었습니다."),
     UNKNOWN_TOKEN(HttpStatus.UNAUTHORIZED,"인증 토큰이 존재하지 않습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다."),
-    HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Authorization 헤더 정보가 존재하지 않습니다.");
+    HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Authorization 헤더 정보가 존재하지 않습니다."),
+    BEARER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Bearer 로 Authorization 헤더가 시작되지 않습니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -15,7 +15,8 @@ public enum HttpExceptionCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NICKNAME_EXIST(HttpStatus.CONFLICT,"이미 존재하는 닉네임 입니다."),
     USERID_EXIST(HttpStatus.CONFLICT,"이미 존재하는 아이디입니다."),
-    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다. 기한이 만료되었거나, 이미 로그아웃이 완료되어 DB에 존재하지 않는 상태입니다.");
+    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다. 기한이 만료되었거나, 이미 로그아웃이 완료되어 DB에 존재하지 않는 상태입니다."),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"만료된 토큰입니다. 토큰을 재발급하세요");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/security/BearerNotFoundException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/security/BearerNotFoundException.java
@@ -9,14 +9,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 @Slf4j
-public class TokenExpiredException extends RuntimeException{
+public class BearerNotFoundException extends RuntimeException{
     private final HttpStatus httpStatus;
-    public TokenExpiredException(HttpExceptionCode exceptionCode) {
+    public BearerNotFoundException(HttpExceptionCode exceptionCode) {
         super(exceptionCode.getMessage());
         this.httpStatus=exceptionCode.getHttpStatus();
     }
 
 
-    public TokenExpiredException(){
-        this(HttpExceptionCode.EXPIRED_TOKEN);}
+    public BearerNotFoundException(){
+        this(HttpExceptionCode.BEARER_NOT_FOUND);}
 }

--- a/src/main/java/com/swig/zigzzang/global/exception/custom/security/TokenExpiredException.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/custom/security/TokenExpiredException.java
@@ -1,0 +1,22 @@
+package com.swig.zigzzang.global.exception.custom.security;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Slf4j
+public class TokenExpiredException extends RuntimeException{
+    private final HttpStatus httpStatus;
+    public TokenExpiredException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus=exceptionCode.getHttpStatus();
+    }
+
+
+    public TokenExpiredException(){
+        this(HttpExceptionCode.EXPIRED_TOKEN);}
+}

--- a/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
@@ -4,6 +4,7 @@ package com.swig.zigzzang.global.exception.handler.security;
 import com.swig.zigzzang.global.exception.custom.security.IncorrectRefreshTokenException;
 import com.swig.zigzzang.global.exception.custom.security.RefreshTokenNotFoundException;
 import com.swig.zigzzang.global.exception.custom.security.SecurityJwtNotFoundException;
+import com.swig.zigzzang.global.exception.custom.security.TokenExpiredException;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +36,12 @@ public class SecurityExceptionHandler {
     @ExceptionHandler(IncorrectRefreshTokenException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public HttpResponse<ErrorResponse> incorrectRefreshTokenExceptionHandler(IncorrectRefreshTokenException e) {
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    @ExceptionHandler(TokenExpiredException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public HttpResponse<ErrorResponse> TokenExpiredExceptionHandler(TokenExpiredException e) {
         return HttpResponse.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }

--- a/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/handler/security/SecurityExceptionHandler.java
@@ -4,7 +4,6 @@ package com.swig.zigzzang.global.exception.handler.security;
 import com.swig.zigzzang.global.exception.custom.security.IncorrectRefreshTokenException;
 import com.swig.zigzzang.global.exception.custom.security.RefreshTokenNotFoundException;
 import com.swig.zigzzang.global.exception.custom.security.SecurityJwtNotFoundException;
-import com.swig.zigzzang.global.exception.custom.security.TokenExpiredException;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -39,10 +38,5 @@ public class SecurityExceptionHandler {
         return HttpResponse.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }
-    @ExceptionHandler(TokenExpiredException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public HttpResponse<ErrorResponse> TokenExpiredExceptionHandler(TokenExpiredException e) {
-        return HttpResponse.status(e.getHttpStatus())
-                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
-    }
+
 }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -1,11 +1,16 @@
 package com.swig.zigzzang.global.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
 import com.swig.zigzzang.member.domain.Member;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springdoc.api.ErrorMessage;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,10 +29,9 @@ public class JWTFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String authorization= request.getHeader("Authorization");
+        String authorization = request.getHeader("Authorization");
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            System.out.println("token null");
             filterChain.doFilter(request, response);
             return;
 
@@ -35,14 +39,12 @@ public class JWTFilter extends OncePerRequestFilter {
 
         System.out.println("authorization now");
         String token = authorization.split(" ")[1];
-
-        if (jwtUtil.isExpired(token)) {
-
-            System.out.println("token expired");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("AccessToken 기간만료");
-            filterChain.doFilter(request, response);
-
+        try {
+            jwtUtil.validateToken(token);
+        } catch (JwtException e) {
+            String message = e.getMessage();
+            if(HttpExceptionCode.EXPIRED_TOKEN.getMessage().equals(message))
+            setResponse(response,HttpExceptionCode.EXPIRED_TOKEN);
             return;
         }
 
@@ -56,9 +58,15 @@ public class JWTFilter extends OncePerRequestFilter {
                 .build();
         CustomUserDetails customUserDetails = new CustomUserDetails(member);
 
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null,
+                customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
+    }
+    private void setResponse(HttpServletResponse response, HttpExceptionCode errorMessage) throws RuntimeException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorMessage.getHttpStatus().value());
+        response.getWriter().print(errorMessage.getMessage());
     }
 }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -31,7 +31,7 @@ public class JWTFilter extends OncePerRequestFilter {
         String authorization = request.getHeader("Authorization");
 
         //Authorization 이 없어도 접근 가능한 api일 경우 통과
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+        if (authorization == null) {
 
             System.out.println("token null");
             filterChain.doFilter(request, response);
@@ -56,6 +56,7 @@ public class JWTFilter extends OncePerRequestFilter {
             if (HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage().equals(message)) {
                 setResponse(response,HttpExceptionCode.UNSUPPORTED_TOKEN);
             }
+
             return;
         }
 

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -39,6 +39,12 @@ public class JWTFilter extends OncePerRequestFilter {
             if (HttpExceptionCode.JWT_NOT_FOUND.getMessage().equals(message)) {
                 setResponse(response,HttpExceptionCode.JWT_NOT_FOUND);
             }
+            if (HttpExceptionCode.WRONG_TYPE_TOKEN.getMessage().equals(message)) {
+                setResponse(response, HttpExceptionCode.WRONG_TYPE_TOKEN);
+            }
+            if (HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage().equals(message)) {
+                setResponse(response,HttpExceptionCode.UNSUPPORTED_TOKEN);
+            }
             return;
         }
 

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -28,6 +28,17 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        //Authorization 이 없어도 접근 가능한 api일 경우 통과
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+
+            return;
+        }
 
         try {
             jwtUtil.validateToken(request);
@@ -44,9 +55,6 @@ public class JWTFilter extends OncePerRequestFilter {
             }
             if (HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage().equals(message)) {
                 setResponse(response,HttpExceptionCode.UNSUPPORTED_TOKEN);
-            }
-            if (HttpExceptionCode.HEADER_NOT_FOUND.getMessage().equals(message)) {
-                setResponse(response,HttpExceptionCode.HEADER_NOT_FOUND);
             }
             return;
         }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTFilter.java
@@ -45,6 +45,9 @@ public class JWTFilter extends OncePerRequestFilter {
             if (HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage().equals(message)) {
                 setResponse(response,HttpExceptionCode.UNSUPPORTED_TOKEN);
             }
+            if (HttpExceptionCode.HEADER_NOT_FOUND.getMessage().equals(message)) {
+                setResponse(response,HttpExceptionCode.HEADER_NOT_FOUND);
+            }
             return;
         }
 

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -1,7 +1,15 @@
 package com.swig.zigzzang.global.security;
 
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import com.swig.zigzzang.global.exception.custom.security.TokenExpiredException;
 import com.swig.zigzzang.global.redis.RedisService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -87,5 +95,15 @@ public class JWTUtil {
             return bearerToken.substring(7);
         }
         return null;
+    }
+    public boolean validateToken(String token) {
+        try {
+
+            Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(HttpExceptionCode.EXPIRED_TOKEN.getMessage());
+        }
+          return true;
+
     }
 }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -109,6 +109,8 @@ public class JWTUtil {
             throw new JwtException(HttpExceptionCode.WRONG_TYPE_TOKEN.getMessage());
         } catch (MalformedJwtException e) { //토큰 길이나 형식이 다른 경우
             throw new JwtException(HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage());
+        } catch (NullPointerException e) {
+            throw new JwtException(HttpExceptionCode.HEADER_NOT_FOUND.getMessage());
         }
 
 

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -102,9 +103,15 @@ public class JWTUtil {
             Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             throw new JwtException(HttpExceptionCode.EXPIRED_TOKEN.getMessage());
-        } catch (ArrayIndexOutOfBoundsException e) {
+        } catch (ArrayIndexOutOfBoundsException e) {//토큰이 존재하지 않을 경우
             throw new JwtException(HttpExceptionCode.JWT_NOT_FOUND.getMessage());
+        } catch (SignatureException e) {//토큰이 임의의 값으로 변경된 경우
+            throw new JwtException(HttpExceptionCode.WRONG_TYPE_TOKEN.getMessage());
+        } catch (MalformedJwtException e) { //토큰 길이나 형식이 다른 경우
+            throw new JwtException(HttpExceptionCode.UNSUPPORTED_TOKEN.getMessage());
         }
+
+
           return true;
 
     }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -96,14 +96,21 @@ public class JWTUtil {
         }
         return null;
     }
-    public boolean validateToken(String token) {
+    public boolean validateToken(HttpServletRequest request) {
         try {
-
+            String token = extractHeader(request);
             Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
             throw new JwtException(HttpExceptionCode.EXPIRED_TOKEN.getMessage());
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new JwtException(HttpExceptionCode.JWT_NOT_FOUND.getMessage());
         }
           return true;
 
+    }
+    public static String extractHeader(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        String token = authorization.split(" ")[1];
+        return token;
     }
 }

--- a/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
+++ b/src/main/java/com/swig/zigzzang/global/security/JWTUtil.java
@@ -105,8 +105,6 @@ public class JWTUtil {
         try {
             String token = extractHeader(request);
             Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
-        } catch (BearerNotFoundException e) {//토큰이 bearer로 시작되지 않는경우
-            throw new JwtException(HttpExceptionCode.BEARER_NOT_FOUND.getMessage());
         } catch (ExpiredJwtException e) {
             throw new JwtException(HttpExceptionCode.EXPIRED_TOKEN.getMessage());
         } catch (ArrayIndexOutOfBoundsException e) {//토큰이 존재하지 않을 경우
@@ -123,9 +121,6 @@ public class JWTUtil {
 
     public static String extractHeader(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
-        if (!authorization.startsWith("Bearer ")) {
-            throw new BearerNotFoundException();
-        }
         String token = authorization.split(" ")[1];
         return token;
     }

--- a/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
+++ b/src/main/java/com/swig/zigzzang/global/security/LoginFilter.java
@@ -50,7 +50,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String password = customUserDetails.getPassword();
         //AT : 6분
-        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*10L);
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 

--- a/src/main/java/com/swig/zigzzang/global/security/ResponseVO.java
+++ b/src/main/java/com/swig/zigzzang/global/security/ResponseVO.java
@@ -1,0 +1,13 @@
+package com.swig.zigzzang.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ResponseVO {
+    private final HttpStatus status;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/EmailCodeFailedException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/EmailCodeFailedException.java
@@ -1,0 +1,24 @@
+package com.swig.zigzzang.member.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Slf4j
+public class EmailCodeFailedException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public EmailCodeFailedException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public EmailCodeFailedException() {
+        this(HttpExceptionCode.EMAIL_FAILED);
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
@@ -2,6 +2,7 @@ package com.swig.zigzzang.member.exception.handler;
 
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
+import com.swig.zigzzang.member.exception.EmailCodeFailedException;
 import com.swig.zigzzang.member.exception.MemberExistException;
 import com.swig.zigzzang.member.exception.MemberNotFoundException;
 import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
@@ -40,6 +41,12 @@ public class MemberExceptionHandler {
     @ExceptionHandler(MemberNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ResponseEntity<ErrorResponse> memberNotFoundExceptionHandler(MemberNotFoundException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+    @ExceptionHandler(EmailCodeFailedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<ErrorResponse> emailCodeFailedExceptionHandler(EmailCodeFailedException e) {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.swig.zigzzang.global.redis.RedisService;
 import com.swig.zigzzang.global.security.JWTUtil;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
+import com.swig.zigzzang.member.exception.EmailCodeFailedException;
 import com.swig.zigzzang.member.exception.MemberExistException;
 import com.swig.zigzzang.member.exception.MemberNotFoundException;
 import com.swig.zigzzang.member.exception.NickNameAlreadyExistException;
@@ -96,6 +97,9 @@ public class MemberService {
         String redisAuthCode = redisService.getValues(AUTH_CODE_PREFIX + email);
         //현재 redis 저장값과 비교(redis 저장코드는 이메일 송신시마다 overwrite)
         boolean authResult = redisService.checkExistsValue(redisAuthCode) && redisAuthCode.equals(authCode);
+        if (!authResult) {
+            throw new EmailCodeFailedException();
+        }
 
         return authResult;
     }


### PR DESCRIPTION
### 요약
JWT 토큰 상태(부존재,형식 불일치, 길이 불일치) 의 예외를 처리하였습니다.
이메일 인증시 인증코드 불일치 예외를 처리하였습니다.

### 상세
우선적으로 `springsecurity`는` @RestControllerAdvice` 을 통한 예외처리가 불가능 합니다. 이유는 서블릿 필터에서 인증 과정을 처리하기 때문입니다. 그래서 해당 시도 실패후, 서블릿 필터 내에서 예외를 처리하여 반환하는 방식으로 구현하였습니다.
또한 문제가, 인증 과정이 필요하지 않은 api의 경우(헤더에 "Authorization"이 존재하지 않을 경우", 토큰 인증 메서드 호출 전 dofilter 처리를 하여서 토큰 검증 로직이 호출되지 않도록 하였습니다. 만약 그래도 허용된 api가 아니면 403 forbidden이 나도록 하였습니다. 
