### PR TITLE
➕ [Feat] : 아이디/비밀번호 찾기 기능 구현

### DIFF
--- a/src/main/java/com/swig/zigzzang/email/dto/LoginRequest.java
+++ b/src/main/java/com/swig/zigzzang/email/dto/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.swig.zigzzang.email.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoginRequest( String username, String password) {
+}

--- a/src/main/java/com/swig/zigzzang/email/exception/handler/EmailExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/email/exception/handler/EmailExceptionHandler.java
@@ -16,10 +16,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class EmailExceptionHandler {
-    @ExceptionHandler(EmailNotSendException.class)  // Add a new exception handler for BusinessLogicException
-    @ResponseStatus(HttpStatus.BAD_REQUEST)  // You can set an appropriate HTTP status for this exception
-    public ResponseEntity<ErrorResponse> EmailnotSendExceptionHandler(EmailNotSendException e) {
-        return ResponseEntity.status(e.getHttpStatus())
+    @ExceptionHandler(EmailNotSendException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public HttpResponse<ErrorResponse> EmailnotSendExceptionHandler(EmailNotSendException e) {
+        return HttpResponse.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }
 }

--- a/src/main/java/com/swig/zigzzang/email/service/EmailService.java
+++ b/src/main/java/com/swig/zigzzang/email/service/EmailService.java
@@ -27,17 +27,15 @@ public class EmailService {
                           String title,
                           String text) {
         SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
-//        try {
+        try {
             emailSender.send(emailForm);
-//        } catch (RuntimeException e) {
-//            System.out.println("e.getMessage() = " + e.getMessage());
-//            log.info("MailService.sendEmail exception occur toEmail: {}, " +
-//                    "title: {}, text: {}", toEmail, title, text);
-//            throw new EmailNotSendException(HttpExceptionCode.UNABLE_TO_SEND_EMAIL);
-//        }
+        } catch (RuntimeException e) {
+
+            throw new EmailNotSendException(HttpExceptionCode.UNABLE_TO_SEND_EMAIL);
+        }
     }
 
-    // 발신할 이메일 데이터 세팅
+
     private SimpleMailMessage createEmailForm(String toEmail,
                                               String title,
                                               String text) {

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -22,7 +22,9 @@ public enum HttpExceptionCode {
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"토큰의 길이나 형식이 올바르지 않습니다."),
     HEADER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Authorization 헤더 정보가 존재하지 않습니다."),
     BEARER_NOT_FOUND(HttpStatus.UNAUTHORIZED,"Bearer 로 Authorization 헤더가 시작되지 않습니다."),
-    EMAIL_FAILED(HttpStatus.UNAUTHORIZED,"이메일 코드가 올바르지 않습니다.");
+    EMAIL_FAILED(HttpStatus.UNAUTHORIZED,"이메일 인증 코드가 올바르지 않습니다."),
+    EMAIL_USER_NOTFOUND(HttpStatus.NOT_FOUND, "해당하는 이메일의 사용자가 존재하지 않습니다."),
+    EMAIL_USERID_USER_NOT(HttpStatus.NOT_FOUND, "해당하는 이메일, 아이디에 일치하는 사용자를 찾을수 없습니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -6,6 +6,8 @@ import com.swig.zigzzang.global.security.JWTUtil;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.member.dto.FindIdRequest;
 import com.swig.zigzzang.member.dto.FindIdResponse;
+import com.swig.zigzzang.member.dto.FindPasswordRequest;
+import com.swig.zigzzang.member.dto.FindPasswordResponse;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.dto.MemberJoinResponse;
 import com.swig.zigzzang.member.dto.MemberLogoutResponse;
@@ -72,6 +74,15 @@ public class MemberController {
         String foundId = memberService.findIdByEmail(findIdRequest.email());
         return HttpResponse.okBuild(
                 FindIdResponse.of(foundId)
+        );
+    }
+
+    @PostMapping("/find-password")
+    @Operation(summary = "비밀번호 찾기", description = "아이디와 이메일로 임시 비밀번호를 발급합니다.")
+    public HttpResponse<FindPasswordResponse> findPassword(@Valid @RequestBody FindPasswordRequest findPasswordRequest) {
+        String email = memberService.findPassword(findPasswordRequest.userId(), findPasswordRequest.email());
+        return HttpResponse.okBuild(
+                FindPasswordResponse.of(email)
         );
     }
 

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -4,6 +4,8 @@ import com.swig.zigzzang.email.dto.EmailResponseDto;
 import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.global.security.JWTUtil;
 import com.swig.zigzzang.member.domain.Member;
+import com.swig.zigzzang.member.dto.FindIdRequest;
+import com.swig.zigzzang.member.dto.FindIdResponse;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.dto.MemberJoinResponse;
 import com.swig.zigzzang.member.dto.MemberLogoutResponse;
@@ -61,6 +63,15 @@ public class MemberController {
 
         return HttpResponse.okBuild(
                 MemberLogoutResponse.from(username,blacklist)
+        );
+    }
+
+    @PostMapping("/find-id")
+    @Operation(summary = "아이디 찾기", description = "이메일을 통해 사용자 아이디를 찾습니다.")
+    public HttpResponse<FindIdResponse> findId(@Valid @RequestBody FindIdRequest findIdRequest) {
+        String foundId = memberService.findIdByEmail(findIdRequest.email());
+        return HttpResponse.okBuild(
+                FindIdResponse.of(foundId)
         );
     }
 

--- a/src/main/java/com/swig/zigzzang/member/domain/Member.java
+++ b/src/main/java/com/swig/zigzzang/member/domain/Member.java
@@ -45,6 +45,9 @@ public class Member extends BaseEntity {
     @Column
     private String email;
 
+    @Column
+    private String profileimage;
+
     @OneToMany(mappedBy = "member")
     private List<Survey> surveys;
 }

--- a/src/main/java/com/swig/zigzzang/member/dto/FindIdRequest.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/FindIdRequest.java
@@ -1,0 +1,11 @@
+package com.swig.zigzzang.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record FindIdRequest(
+        @NotBlank(message = "Email은 필수 입력 값입니다.")
+        @Email(message = "이메일 형식에 맞지 않습니다.")
+         String email
+) {
+}

--- a/src/main/java/com/swig/zigzzang/member/dto/FindIdResponse.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/FindIdResponse.java
@@ -1,0 +1,15 @@
+package com.swig.zigzzang.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FindIdResponse(String userId) {
+
+    public static FindIdResponse of(String userId) {
+        FindIdResponse response=
+                FindIdResponse.builder()
+                        .userId(userId)
+                        .build();
+        return response;
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/dto/FindPasswordRequest.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/FindPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.swig.zigzzang.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record FindPasswordRequest(
+        @NotBlank(message = "사용자 이름은 필수 입력값입니다.")
+         String userId,
+
+        @NotBlank(message = "이메일 값은 필수 입력 값입니다.")
+        @Email(message = "이메일 형식에 맞지 않습니다.")
+         String email
+) {
+
+}

--- a/src/main/java/com/swig/zigzzang/member/dto/FindPasswordResponse.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/FindPasswordResponse.java
@@ -1,0 +1,17 @@
+package com.swig.zigzzang.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FindPasswordResponse(String message) {
+
+    public static FindPasswordResponse of(String email) {
+
+
+        return FindPasswordResponse.builder()
+                .message(email+"로 임시 비밀번호를 보냈습니다.")
+                .build();
+
+
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
+++ b/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
@@ -10,4 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByUserIdAndEmail(String userId, String email);
+
 }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -157,4 +157,10 @@ public class MemberService {
     private String getAccessToken( Member user) {
         return jwtUtil.createJwt(user.getUserId(), user.getPassword(), 86400000 * 7L);
     }
+
+    public String findIdByEmail(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+        return member.getUserId();
+    }
 }

--- a/src/main/java/com/swig/zigzzang/survey/domain/Survey.java
+++ b/src/main/java/com/swig/zigzzang/survey/domain/Survey.java
@@ -41,4 +41,10 @@ public class Survey extends BaseEntity {
     @Column
     private String presentedSymptom;
 
+    @Column
+    private String  department;
+
+    @Column
+    private String  disease;
+
 }

--- a/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveRequest.java
+++ b/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveRequest.java
@@ -3,14 +3,16 @@ package com.swig.zigzzang.survey.dto;
 import com.swig.zigzzang.member.domain.Member;
 import com.swig.zigzzang.survey.domain.Survey;
 
-public record SurveySaveRequest(String userId, String targetBodyPart, String diagnosisPart, String presentedSymptom) {
+public record SurveySaveRequest( String targetBodyPart, String diagnosisPart, String presentedSymptom, String department, String disease) {
 
     public  Survey toEntity(Member member) {
-       return Survey.builder()
+        return Survey.builder()
                 .member(member)
                 .targetBody(targetBodyPart)
                 .diagnosisPart(diagnosisPart)
                 .presentedSymptom(presentedSymptom)
+                .department(department)
+                .disease(disease)
                 .build();
 
     }

--- a/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveResponse.java
+++ b/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveResponse.java
@@ -12,6 +12,8 @@ public record SurveySaveResponse(
         String targetBodyPart,
         String diagnosisPart,
         String presentedSymptom,
+        String disease,
+        String department,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
         LocalDateTime savedAt
 ) {
@@ -22,6 +24,8 @@ public record SurveySaveResponse(
                 .diagnosisPart(survey.getDiagnosisPart())
                 .presentedSymptom(survey.getPresentedSymptom())
                 .targetBodyPart(survey.getTargetBody())
+                .disease(survey.getDisease())
+                .department(survey.getDepartment())
                 .savedAt(survey.createdDate)
                 .build();
     }

--- a/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
+++ b/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
@@ -7,6 +7,7 @@ import com.swig.zigzzang.member.repository.MemberRepository;
 import com.swig.zigzzang.survey.domain.Survey;
 import com.swig.zigzzang.survey.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,7 +17,9 @@ public class SurveyService {
     private final SurveyRepository surveyRepository;
 
     public Survey saveSurveyResult(SurveySaveRequest surveyrequest) {
-        Member member = memberRepository.findByUserId(surveyrequest.userId())
+        String userid= SecurityContextHolder.getContext().getAuthentication()
+                .getName();
+        Member member = memberRepository.findByUserId(userid)
                 .orElseThrow(MemberNotFoundException::new);
 
         Survey result = surveyrequest.toEntity(member);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     defer-datasource-initialization: true
   jwt:
     secret: ${jwt_secret}


### PR DESCRIPTION
### 요약
1. 이메일 인증을 통한 아이디와 비밀번호를 찾는 기능을 구현하였습니다.
2. 건강설문 저장시 입력 파라미터 값을 변경하였습니다. 

### 상세
이메일을 통해 `10자리 난수`로 생성된 임시 비밀번호를 발급하는 기능을 구현하였습니다. 또한 해당 난수를 DB에도 반영하도록 구현하였습니다. 아이디는 인증된 이메일로 찾을수 있도록 구현하였습니다.
또한, 관련 커스텀 익셉션을 정의하였고, handler 또한 정의하였습니다.
건강설문 api에서 헤더에 `AccessToken`을 넣어서 보내면, 해당 정보를 이용하여 유저를 찾을수 있도록 하였고, 그로인해 요청 파라미터에 `userid`를 삭제하였습니다. 또한 프론트 분의 요청에 따라 `disease`,`department`(질병, 분과) 를 요청/응답 값으로 수정하였습니다.