### PR TITLE
📌 [Feat] :  건강설문 목록 조회시 N+1 문제 해결

### DIFF
--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -35,7 +35,9 @@ public enum HttpExceptionCode {
 
     COMMENT_UPDATE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"수정 권한이 없습니다."),
 
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자의 이메일을 찾을수 없습니다.");
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자의 이메일을 찾을수 없습니다."),
+    SURVERY_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 Surveyid의 질병설문을 찾을수 없습니다."),
+    SURVERY_MEMBER_NOT_EQUAL(HttpStatus.CONFLICT,"해당 Surveyid의 질병설문을 찾을수 없습니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -33,7 +33,9 @@ public enum HttpExceptionCode {
 
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호 확인과 새로운 비밀번호가 일치하지 않습니다."),
 
-    COMMENT_UPDATE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"수정 권한이 없습니다.");
+    COMMENT_UPDATE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"수정 권한이 없습니다."),
+
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자의 이메일을 찾을수 없습니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/swig/zigzzang/global/exception/HttpExceptionCode.java
@@ -37,7 +37,7 @@ public enum HttpExceptionCode {
 
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자의 이메일을 찾을수 없습니다."),
     SURVERY_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 Surveyid의 질병설문을 찾을수 없습니다."),
-    SURVERY_MEMBER_NOT_EQUAL(HttpStatus.CONFLICT,"해당 Surveyid의 질병설문을 찾을수 없습니다.");
+    SURVERY_MEMBER_NOT_EQUAL(HttpStatus.CONFLICT,"해당 사용자의 질병설문이 아닙니다.");
 
 
 

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import com.swig.zigzzang.member.dto.MemberLogoutResponse;
 import com.swig.zigzzang.member.dto.MypageResponse;
 import com.swig.zigzzang.member.dto.TokenRefreshRequest;
 import com.swig.zigzzang.member.dto.TokenRefreshResponse;
+import com.swig.zigzzang.member.dto.VerifyEmailRequest;
 import com.swig.zigzzang.member.service.MemberService;
 import com.swig.zigzzang.profile.dto.ChangeProfileImageRequest;
 import com.swig.zigzzang.profile.dto.ChangeProfileImageResponse;
@@ -139,6 +140,12 @@ public class MemberController {
         return HttpResponse.okBuild(
                 MypageResponse.from(member)
         );
+    }
+    @PostMapping("/verify-email")
+    @Operation(summary = "사용자 이메일 확인", description = "DB에 저장된 이메일과 입력된 이메일을 비교하여 확인합니다.")
+    public HttpResponse<String> verifyEmail(@RequestBody VerifyEmailRequest verifyEmailRequest) {
+        memberService.verifyEmail(verifyEmailRequest.email());
+        return HttpResponse.okBuild("이메일이 확인되었습니다.");
     }
 
 }

--- a/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
+++ b/src/main/java/com/swig/zigzzang/member/controller/MemberController.java
@@ -23,6 +23,7 @@ import com.swig.zigzzang.profile.dto.ChangeProfileImageRequest;
 import com.swig.zigzzang.profile.dto.ChangeProfileImageResponse;
 import com.swig.zigzzang.profile.service.ProfileImageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/members")
+@Tag(name = "MemberController", description = "")
+
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
@@ -142,7 +145,7 @@ public class MemberController {
         );
     }
     @PostMapping("/verify-email")
-    @Operation(summary = "사용자 이메일 확인", description = "DB에 저장된 이메일과 입력된 이메일을 비교하여 확인합니다.")
+    @Operation(summary = "사용자 이메일 확인", description = "비밀번호 변경시 DB에 저장된 이메일과 입력된 이메일을 비교하여 확인합니다.")
     public HttpResponse<String> verifyEmail(@RequestBody VerifyEmailRequest verifyEmailRequest) {
         memberService.verifyEmail(verifyEmailRequest.email());
         return HttpResponse.okBuild("이메일이 확인되었습니다.");

--- a/src/main/java/com/swig/zigzzang/member/domain/Member.java
+++ b/src/main/java/com/swig/zigzzang/member/domain/Member.java
@@ -19,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.jpa.repository.Query;
 
 @Entity
 @AllArgsConstructor

--- a/src/main/java/com/swig/zigzzang/member/dto/VerifyEmailRequest.java
+++ b/src/main/java/com/swig/zigzzang/member/dto/VerifyEmailRequest.java
@@ -1,0 +1,11 @@
+package com.swig.zigzzang.member.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+
+
+public record VerifyEmailRequest(
+        @Email(message = "올바른 이메일 주소를 입력하세요.")
+         String email
+) {
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/EmailVerificationException.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/EmailVerificationException.java
@@ -1,0 +1,20 @@
+package com.swig.zigzzang.member.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+@Getter
+@Setter
+public class EmailVerificationException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public EmailVerificationException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public EmailVerificationException() {
+        this(HttpExceptionCode.EMAIL_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/member/exception/handler/MemberExceptionHandler.java
@@ -3,6 +3,7 @@ package com.swig.zigzzang.member.exception.handler;
 import com.swig.zigzzang.global.response.ErrorResponse;
 import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.member.exception.EmailCodeFailedException;
+import com.swig.zigzzang.member.exception.EmailVerificationException;
 import com.swig.zigzzang.member.exception.IncorrectPasswordException;
 import com.swig.zigzzang.member.exception.MemberExistException;
 import com.swig.zigzzang.member.exception.MemberNotExistException;
@@ -67,6 +68,13 @@ public class MemberExceptionHandler {
     @ExceptionHandler(IncorrectPasswordException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ResponseEntity<ErrorResponse> incorrectPasswordExceptionHandler(IncorrectPasswordException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(EmailVerificationException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse> emailVerificationExceptionHandler(EmailVerificationException e) {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
     }

--- a/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
+++ b/src/main/java/com/swig/zigzzang/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUserIdAndEmail(String userId, String email);
 
+    Boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/swig/zigzzang/member/service/MemberService.java
+++ b/src/main/java/com/swig/zigzzang/member/service/MemberService.java
@@ -12,6 +12,7 @@ import com.swig.zigzzang.member.dto.ChangeNicknameRequest;
 import com.swig.zigzzang.member.dto.ChangePasswordRequest;
 import com.swig.zigzzang.member.dto.MemberJoinRequest;
 import com.swig.zigzzang.member.exception.EmailCodeFailedException;
+import com.swig.zigzzang.member.exception.EmailVerificationException;
 import com.swig.zigzzang.member.exception.IncorrectPasswordException;
 import com.swig.zigzzang.member.exception.MemberExistException;
 import com.swig.zigzzang.member.exception.MemberNotFoundException;
@@ -270,5 +271,10 @@ public class MemberService {
     public Member findMemberByUsername(String username) {
         return memberRepository.findByUserId(username)
                 .orElseThrow(() -> new MemberNotFoundException(HttpExceptionCode.USER_NOT_FOUND));
+    }
+    public void verifyEmail(String email) {
+        if (!memberRepository.existsByEmail(email)) {
+            throw new EmailVerificationException();
+        }
     }
 }

--- a/src/main/java/com/swig/zigzzang/survey/controller/SurveyController.java
+++ b/src/main/java/com/swig/zigzzang/survey/controller/SurveyController.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,5 +43,11 @@ public class SurveyController {
         return HttpResponse.okBuild(
                 surveyList
         );
+    }
+    @DeleteMapping("/delete/{surveyId}")
+    @Operation(summary = "질병리스트 삭제", description = "건강설문을 삭제합니다.")
+    public HttpResponse<String> deleteSurvey(@PathVariable Long surveyId) {
+        surveyService.deleteSurvey(surveyId);
+        return HttpResponse.okBuild("건강설문 삭제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/swig/zigzzang/survey/controller/SurveyController.java
+++ b/src/main/java/com/swig/zigzzang/survey/controller/SurveyController.java
@@ -2,11 +2,15 @@ package com.swig.zigzzang.survey.controller;
 
 import com.swig.zigzzang.global.response.HttpResponse;
 import com.swig.zigzzang.survey.domain.Survey;
+import com.swig.zigzzang.survey.dto.SurveyResponse;
 import com.swig.zigzzang.survey.dto.SurveySaveRequest;
 import com.swig.zigzzang.survey.dto.SurveySaveResponse;
 import com.swig.zigzzang.survey.service.SurveyService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/survey")
+@Tag(name = "SurveyController", description = "건강설문 api")
+
 @RequiredArgsConstructor
 public class SurveyController {
     private final SurveyService surveyService;
@@ -27,5 +33,13 @@ public class SurveyController {
                 SurveySaveResponse.of(savedsurvey)
         );
 
+    }
+    @GetMapping("/list")
+    @Operation(summary = "나의 질병 리스트 조회", description = "로그인한사용자의 건강설문 리스트를 조회합니다.")
+    public HttpResponse<List<SurveyResponse>> getSurveyList() {
+        List<SurveyResponse> surveyList = surveyService.getSurveysByUserId();
+        return HttpResponse.okBuild(
+                surveyList
+        );
     }
 }

--- a/src/main/java/com/swig/zigzzang/survey/dto/SurveyResponse.java
+++ b/src/main/java/com/swig/zigzzang/survey/dto/SurveyResponse.java
@@ -1,0 +1,31 @@
+package com.swig.zigzzang.survey.dto;
+
+import com.swig.zigzzang.survey.domain.Survey;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record SurveyResponse(Long surveyId,
+                             String nickname,
+                             String targetBody,
+                             String diagnosisPart,
+                             String presentedSymptom,
+                             String department,
+                             String disease,
+                             LocalDateTime dateTime
+
+) {
+    public static SurveyResponse of(Survey survey) {
+        return SurveyResponse.builder()
+                .surveyId(survey.getSurveyId())
+                .targetBody(survey.getTargetBody())
+                .diagnosisPart(survey.getDiagnosisPart())
+                .presentedSymptom(survey.getDiagnosisPart())
+                .department(survey.getDepartment())
+                .disease(survey.getDisease())
+                .nickname(survey.getMember().getNickname())
+                .dateTime(survey.getCreatedDate())
+                .build();
+    }
+
+}

--- a/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveResponse.java
+++ b/src/main/java/com/swig/zigzzang/survey/dto/SurveySaveResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record SurveySaveResponse(
-        Long id,
+        Long surveyId,
         String userid,
         String targetBodyPart,
         String diagnosisPart,
@@ -19,7 +19,7 @@ public record SurveySaveResponse(
 ) {
     public static SurveySaveResponse of(Survey survey) {
         return SurveySaveResponse.builder()
-                .id(survey.getSurveyId())
+                .surveyId(survey.getSurveyId())
                 .userid(survey.getMember().getUserId())
                 .diagnosisPart(survey.getDiagnosisPart())
                 .presentedSymptom(survey.getPresentedSymptom())

--- a/src/main/java/com/swig/zigzzang/survey/exception/SurveyMemberNotEqualException.java
+++ b/src/main/java/com/swig/zigzzang/survey/exception/SurveyMemberNotEqualException.java
@@ -1,0 +1,20 @@
+package com.swig.zigzzang.survey.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+@Getter
+@Setter
+public class SurveyMemberNotEqualException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public SurveyMemberNotEqualException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public SurveyMemberNotEqualException() {
+        this(HttpExceptionCode.SURVERY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/survey/exception/SurveyMemberNotEqualException.java
+++ b/src/main/java/com/swig/zigzzang/survey/exception/SurveyMemberNotEqualException.java
@@ -15,6 +15,6 @@ public class SurveyMemberNotEqualException extends RuntimeException{
     }
 
     public SurveyMemberNotEqualException() {
-        this(HttpExceptionCode.SURVERY_NOT_FOUND);
+        this(HttpExceptionCode.SURVERY_MEMBER_NOT_EQUAL);
     }
 }

--- a/src/main/java/com/swig/zigzzang/survey/exception/SurveyNotFoundException.java
+++ b/src/main/java/com/swig/zigzzang/survey/exception/SurveyNotFoundException.java
@@ -1,0 +1,20 @@
+package com.swig.zigzzang.survey.exception;
+
+import com.swig.zigzzang.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+@Getter
+@Setter
+public class SurveyNotFoundException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public SurveyNotFoundException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus = exceptionCode.getHttpStatus();
+    }
+
+    public SurveyNotFoundException() {
+        this(HttpExceptionCode.SURVERY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/swig/zigzzang/survey/exception/handler/SurveyExceptionHandler.java
+++ b/src/main/java/com/swig/zigzzang/survey/exception/handler/SurveyExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.swig.zigzzang.survey.exception.handler;
+
+import com.swig.zigzzang.global.response.ErrorResponse;
+import com.swig.zigzzang.member.exception.MemberExistException;
+import com.swig.zigzzang.survey.exception.SurveyMemberNotEqualException;
+import com.swig.zigzzang.survey.exception.SurveyNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SurveyExceptionHandler {
+
+    @ExceptionHandler(SurveyNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse> memberExistExceptionHandler(SurveyNotFoundException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(SurveyMemberNotEqualException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<ErrorResponse> surveyMemberNotEqualExceptionHandler(SurveyMemberNotEqualException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+    }
+}

--- a/src/main/java/com/swig/zigzzang/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/swig/zigzzang/survey/repository/SurveyRepository.java
@@ -1,6 +1,7 @@
 package com.swig.zigzzang.survey.repository;
 
 import com.swig.zigzzang.survey.domain.Survey;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {

--- a/src/main/java/com/swig/zigzzang/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/swig/zigzzang/survey/repository/SurveyRepository.java
@@ -3,7 +3,10 @@ package com.swig.zigzzang.survey.repository;
 import com.swig.zigzzang.survey.domain.Survey;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
-
+    @Query("select distinct s from Survey s join fetch s.member m where m.userId = :userid")
+    List<Survey> findAllJoinFetch(@Param("userid") String userid);
 }

--- a/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
+++ b/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
@@ -7,8 +7,11 @@ import com.swig.zigzzang.survey.dto.SurveySaveRequest;
 import com.swig.zigzzang.member.exception.MemberNotFoundException;
 import com.swig.zigzzang.member.repository.MemberRepository;
 import com.swig.zigzzang.survey.domain.Survey;
+import com.swig.zigzzang.survey.exception.SurveyMemberNotEqualException;
+import com.swig.zigzzang.survey.exception.SurveyNotFoundException;
 import com.swig.zigzzang.survey.repository.SurveyRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,9 +40,23 @@ public class SurveyService {
 
         List<Survey> surveys = surveyRepository.findAllJoinFetch(userId);
 
-        return  surveys.stream()
+        return surveys.stream()
                 .map(survey -> SurveyResponse.of(survey))
                 .collect(Collectors.toList());
+    }
+
+    public void deleteSurvey(Long surveyId) {
+        String userid = memberService.getUsernameBySecurityContext();
+        Member member = memberRepository.findByUserId(userid)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Survey survey = surveyRepository.findById(surveyId)
+                .orElseThrow(SurveyNotFoundException::new);
+        if (!survey.getMember().getUserId().equals(member.getUserId())) {
+            throw new SurveyMemberNotEqualException();
+        }
+
+        surveyRepository.deleteById(surveyId);
     }
 
 

--- a/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
+++ b/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
@@ -32,10 +32,10 @@ public class SurveyService {
 
     public List<SurveyResponse> getSurveysByUserId() {
         String userId = memberService.getUsernameBySecurityContext();
-        Member member = memberRepository.findByUserId(userId)
+        memberRepository.findByUserId(userId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        List<Survey> surveys = member.getSurveys();
+        List<Survey> surveys = surveyRepository.findAllJoinFetch(userId);
 
         return  surveys.stream()
                 .map(survey -> SurveyResponse.of(survey))

--- a/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
+++ b/src/main/java/com/swig/zigzzang/survey/service/SurveyService.java
@@ -1,11 +1,15 @@
 package com.swig.zigzzang.survey.service;
 
 import com.swig.zigzzang.member.domain.Member;
+import com.swig.zigzzang.member.service.MemberService;
+import com.swig.zigzzang.survey.dto.SurveyResponse;
 import com.swig.zigzzang.survey.dto.SurveySaveRequest;
 import com.swig.zigzzang.member.exception.MemberNotFoundException;
 import com.swig.zigzzang.member.repository.MemberRepository;
 import com.swig.zigzzang.survey.domain.Survey;
 import com.swig.zigzzang.survey.repository.SurveyRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -15,15 +19,27 @@ import org.springframework.stereotype.Service;
 public class SurveyService {
     private final MemberRepository memberRepository;
     private final SurveyRepository surveyRepository;
+    private final MemberService memberService;
 
     public Survey saveSurveyResult(SurveySaveRequest surveyrequest) {
-        String userid= SecurityContextHolder.getContext().getAuthentication()
-                .getName();
+        String userid = memberService.getUsernameBySecurityContext();
         Member member = memberRepository.findByUserId(userid)
                 .orElseThrow(MemberNotFoundException::new);
 
         Survey result = surveyrequest.toEntity(member);
         return surveyRepository.save(result);
+    }
+
+    public List<SurveyResponse> getSurveysByUserId() {
+        String userId = memberService.getUsernameBySecurityContext();
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        List<Survey> surveys = member.getSurveys();
+
+        return  surveys.stream()
+                .map(survey -> SurveyResponse.of(survey))
+                .collect(Collectors.toList());
     }
 
 


### PR DESCRIPTION
### 요약
건강설문 조회시 `1:N` 연관관계에 있던 `Member `엔티티도 함께 조회 쿼리가 날라가는 **N+1 문제**를 해결하였습니다.

### 상세
우선적으로 `FetchJoin`을 써서 지연 로딩 전략으로 데이터를 가져온 이후에 가져온 데이터에서 하위 엔티티를 다시 조회하는 경우(즉 해당 코드에서는 `Survey`와 연관관계가 있는 `Member `테이블을 다시 조회하여서 닉네임을 DTO를 넘겨주는 부분에서 발생) 해당 N+1 문제가 발생되었습니다. 해당 문제를 해결하기 위해서  DB에서 데이터를 가져올때 처음부터 연관된 엔티티나 컬렉션을 한번에 같이 조회하는 `FetchJoin `전략을 사용하였습니다. 즉, `Survey `엔티티를 조회할때 `member`도 같이 조회해서 N번 `Member`를 조회하는 쿼리를 나가지 않도록 하였습니다.